### PR TITLE
feat: target php8 and deprecate wrong type usage

### DIFF
--- a/ForceUTF8/Encoding.php
+++ b/ForceUTF8/Encoding.php
@@ -11,13 +11,10 @@ use function array_values;
 use function chr;
 use function extension_loaded;
 use function function_exists;
-use function iconv;
 use function ini_get;
 use function intdiv;
 use function is_array;
 use function is_string;
-use function mb_convert_encoding;
-use function mb_strlen;
 use function ord;
 use function pack;
 use function preg_replace;
@@ -27,15 +24,10 @@ use function strtoupper;
 use function substr;
 use function utf8_decode;
 
-class Encoding {
-
-  const ICONV_TRANSLIT = "TRANSLIT";
-  const ICONV_IGNORE = "IGNORE";
-  const WITHOUT_ICONV = "";
-
-  protected static $win1252ToUtf8 = array(
+class Encoding
+{
+    protected const WIN1252_TO_UTF8 = [
         128 => "\xe2\x82\xac",
-
         130 => "\xe2\x80\x9a",
         131 => "\xc6\x92",
         132 => "\xe2\x80\x9e",
@@ -47,10 +39,7 @@ class Encoding {
         138 => "\xc5\xa0",
         139 => "\xe2\x80\xb9",
         140 => "\xc5\x92",
-
         142 => "\xc5\xbd",
-
-
         145 => "\xe2\x80\x98",
         146 => "\xe2\x80\x99",
         147 => "\xe2\x80\x9c",
@@ -63,14 +52,12 @@ class Encoding {
         154 => "\xc5\xa1",
         155 => "\xe2\x80\xba",
         156 => "\xc5\x93",
-
         158 => "\xc5\xbe",
         159 => "\xc5\xb8"
-  );
+    ];
 
-    protected static $brokenUtf8ToUtf8 = array(
+    protected const BROKEN_UTF8_TO_UTF8 = [
         "\xc2\x80" => "\xe2\x82\xac",
-
         "\xc2\x82" => "\xe2\x80\x9a",
         "\xc2\x83" => "\xc6\x92",
         "\xc2\x84" => "\xe2\x80\x9e",
@@ -82,10 +69,7 @@ class Encoding {
         "\xc2\x8a" => "\xc5\xa0",
         "\xc2\x8b" => "\xe2\x80\xb9",
         "\xc2\x8c" => "\xc5\x92",
-
         "\xc2\x8e" => "\xc5\xbd",
-
-
         "\xc2\x91" => "\xe2\x80\x98",
         "\xc2\x92" => "\xe2\x80\x99",
         "\xc2\x93" => "\xe2\x80\x9c",
@@ -98,247 +82,312 @@ class Encoding {
         "\xc2\x9a" => "\xc5\xa1",
         "\xc2\x9b" => "\xe2\x80\xba",
         "\xc2\x9c" => "\xc5\x93",
-
         "\xc2\x9e" => "\xc5\xbe",
         "\xc2\x9f" => "\xc5\xb8"
-  );
+    ];
 
-  protected static $utf8ToWin1252 = array(
-       "\xe2\x82\xac" => "\x80",
+    protected const UTF8_TO_WIN1252 = [
+        "\xe2\x82\xac" => "\x80",
+        "\xe2\x80\x9a" => "\x82",
+        "\xc6\x92" => "\x83",
+        "\xe2\x80\x9e" => "\x84",
+        "\xe2\x80\xa6" => "\x85",
+        "\xe2\x80\xa0" => "\x86",
+        "\xe2\x80\xa1" => "\x87",
+        "\xcb\x86" => "\x88",
+        "\xe2\x80\xb0" => "\x89",
+        "\xc5\xa0" => "\x8a",
+        "\xe2\x80\xb9" => "\x8b",
+        "\xc5\x92" => "\x8c",
+        "\xc5\xbd" => "\x8e",
+        "\xe2\x80\x98" => "\x91",
+        "\xe2\x80\x99" => "\x92",
+        "\xe2\x80\x9c" => "\x93",
+        "\xe2\x80\x9d" => "\x94",
+        "\xe2\x80\xa2" => "\x95",
+        "\xe2\x80\x93" => "\x96",
+        "\xe2\x80\x94" => "\x97",
+        "\xcb\x9c" => "\x98",
+        "\xe2\x84\xa2" => "\x99",
+        "\xc5\xa1" => "\x9a",
+        "\xe2\x80\xba" => "\x9b",
+        "\xc5\x93" => "\x9c",
+        "\xc5\xbe" => "\x9e",
+        "\xc5\xb8" => "\x9f"
+    ];
 
-       "\xe2\x80\x9a" => "\x82",
-       "\xc6\x92"     => "\x83",
-       "\xe2\x80\x9e" => "\x84",
-       "\xe2\x80\xa6" => "\x85",
-       "\xe2\x80\xa0" => "\x86",
-       "\xe2\x80\xa1" => "\x87",
-       "\xcb\x86"     => "\x88",
-       "\xe2\x80\xb0" => "\x89",
-       "\xc5\xa0"     => "\x8a",
-       "\xe2\x80\xb9" => "\x8b",
-       "\xc5\x92"     => "\x8c",
-
-       "\xc5\xbd"     => "\x8e",
-
-
-       "\xe2\x80\x98" => "\x91",
-       "\xe2\x80\x99" => "\x92",
-       "\xe2\x80\x9c" => "\x93",
-       "\xe2\x80\x9d" => "\x94",
-       "\xe2\x80\xa2" => "\x95",
-       "\xe2\x80\x93" => "\x96",
-       "\xe2\x80\x94" => "\x97",
-       "\xcb\x9c"     => "\x98",
-       "\xe2\x84\xa2" => "\x99",
-       "\xc5\xa1"     => "\x9a",
-       "\xe2\x80\xba" => "\x9b",
-       "\xc5\x93"     => "\x9c",
-
-       "\xc5\xbe"     => "\x9e",
-       "\xc5\xb8"     => "\x9f"
-    );
-
-  /**
-   * Function \ForceUTF8\Encoding::toUTF8
-   *
-   * This function leaves UTF8 characters alone, while converting almost all non-UTF8 to UTF8.
-   *
-   * It assumes that the encoding of the original string is either Windows-1252 or ISO 8859-1.
-   *
-   * It may fail to convert characters to UTF-8 if they fall into one of these scenarios:
-   *
-   * 1) when any of these characters:   ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞß
-   *    are followed by any of these:  ("group B")
-   *                                    ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶•¸¹º»¼½¾¿
-   * For example:   %ABREPRESENT%C9%BB. «REPRESENTÉ»
-   * The "«" (%AB) character will be converted, but the "É" followed by "»" (%C9%BB)
-   * is also a valid unicode character, and will be left unchanged.
-   *
-   * 2) when any of these: àáâãäåæçèéêëìíîï  are followed by TWO chars from group B,
-   * 3) when any of these: ðñòó  are followed by THREE chars from group B.
-   *
-   * @param string|array $text  Any string.
-   * @return string|array  The same string, UTF8 encoded
-   *
-   */
-  public static function toUTF8($text)
-  {
-
-    if(is_array($text))
+    /**
+     * Function \ForceUTF8\Encoding::toUTF8
+     * This function leaves UTF8 characters alone, while converting almost all non-UTF8 to UTF8.
+     * It assumes that the encoding of the original string is either Windows-1252 or ISO 8859-1.
+     * It may fail to convert characters to UTF-8 if they fall into one of these scenarios:
+     * 1) when any of these characters:   ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞß
+     *    are followed by any of these:  ("group B")
+     *                                    ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶•¸¹º»¼½¾¿
+     * For example:   %ABREPRESENT%C9%BB. «REPRESENTÉ»
+     * The "«" (%AB) character will be converted, but the "É" followed by "»" (%C9%BB)
+     * is also a valid unicode character, and will be left unchanged.
+     * 2) when any of these: àáâãäåæçèéêëìíîï  are followed by TWO chars from group B,
+     * 3) when any of these: ðñòó  are followed by THREE chars from group B.
+     *
+     * @param string|string[] $text Any string.
+     * @return string|string[]  The same string, UTF8 encoded
+     */
+    public static function toUTF8($text)
     {
-      foreach($text as $k => $v)
-      {
-        $text[$k] = self::toUTF8($v);
-      }
-      return $text;
-    }
+        if (is_array($text)) {
+            foreach ($text as $k => $v) {
+                $text[$k] = self::toUTF8($v);
+            }
+            return $text;
+        }
 
-    if(!is_string($text)) {
-      return $text;
-    }
+        if (!is_string($text)) {
+            trigger_error('Deprecated: $text must be a string or an array of string', E_USER_DEPRECATED);
+            return $text;
+        }
 
-    $max = self::strlen($text);
+        $max = self::strlen($text);
 
-    $buf = "";
-    for($i = 0; $i < $max; $i++){
-        $c1 = $text[$i];
-        if($c1>="\xc0"){ //Should be converted to UTF8, if it's not UTF8 already
-          $c2 = $i+1 >= $max? "\x00" : $text[$i+1];
-          $c3 = $i+2 >= $max? "\x00" : $text[$i+2];
-          $c4 = $i+3 >= $max? "\x00" : $text[$i+3];
-            if($c1 >= "\xc0" & $c1 <= "\xdf"){ //looks like 2 bytes UTF8
-                if($c2 >= "\x80" && $c2 <= "\xbf"){ //yeah, almost sure it's UTF8 already
-                    $buf .= $c1 . $c2;
-                    $i++;
-                } else { //not valid UTF8.  Convert it.
-                    $cc1 = (chr(intdiv(ord($c1), 64)) | "\xc0");
-                    $cc2 = ($c1 & "\x3f") | "\x80";
-                    $buf .= $cc1 . $cc2;
-                }
-            } elseif($c1 >= "\xe0" & $c1 <= "\xef"){ //looks like 3 bytes UTF8
-                if($c2 >= "\x80" && $c2 <= "\xbf" && $c3 >= "\x80" && $c3 <= "\xbf"){ //yeah, almost sure it's UTF8 already
-                    $buf .= $c1 . $c2 . $c3;
-                    $i = $i + 2;
-                } else { //not valid UTF8.  Convert it.
-                    $cc1 = (chr(intdiv(ord($c1), 64)) | "\xc0");
-                    $cc2 = ($c1 & "\x3f") | "\x80";
-                    $buf .= $cc1 . $cc2;
-                }
-            } elseif($c1 >= "\xf0" & $c1 <= "\xf7"){ //looks like 4 bytes UTF8
-                if($c2 >= "\x80" && $c2 <= "\xbf" && $c3 >= "\x80" && $c3 <= "\xbf" && $c4 >= "\x80" && $c4 <= "\xbf"){ //yeah, almost sure it's UTF8 already
-                    $buf .= $c1 . $c2 . $c3 . $c4;
-                    $i = $i + 3;
-                } else { //not valid UTF8.  Convert it.
-                    $cc1 = (chr(intdiv(ord($c1), 64)) | "\xc0");
-                    $cc2 = ($c1 & "\x3f") | "\x80";
-                    $buf .= $cc1 . $cc2;
-                }
-            } else { //doesn't look like UTF8, but should be converted
+        $buf = "";
+        for ($i = 0; $i < $max; $i++) {
+            $c1 = $text[$i];
+            if ($c1 >= "\xc0") { //Should be converted to UTF8, if it's not UTF8 already
+                $c2 = $i + 1 >= $max ? "\x00" : $text[$i + 1];
+                $c3 = $i + 2 >= $max ? "\x00" : $text[$i + 2];
+                $c4 = $i + 3 >= $max ? "\x00" : $text[$i + 3];
+                if ($c1 >= "\xc0" & $c1 <= "\xdf") { //looks like 2 bytes UTF8
+                    if ($c2 >= "\x80" && $c2 <= "\xbf") { //yeah, almost sure it's UTF8 already
+                        $buf .= $c1 . $c2;
+                        $i++;
+                    } else { //not valid UTF8.  Convert it.
+                        $cc1 = (chr(intdiv(ord($c1), 64)) | "\xc0");
+                        $cc2 = ($c1 & "\x3f") | "\x80";
+                        $buf .= $cc1 . $cc2;
+                    }
+                } elseif ($c1 >= "\xe0" & $c1 <= "\xef") { //looks like 3 bytes UTF8
+                    if ($c2 >= "\x80" && $c2 <= "\xbf" && $c3 >= "\x80" && $c3 <= "\xbf") { //yeah, almost sure it's UTF8 already
+                        $buf .= $c1 . $c2 . $c3;
+                        $i = $i + 2;
+                    } else { //not valid UTF8.  Convert it.
+                        $cc1 = (chr(intdiv(ord($c1), 64)) | "\xc0");
+                        $cc2 = ($c1 & "\x3f") | "\x80";
+                        $buf .= $cc1 . $cc2;
+                    }
+                } elseif ($c1 >= "\xf0" & $c1 <= "\xf7") { //looks like 4 bytes UTF8
+                    if ($c2 >= "\x80" && $c2 <= "\xbf" && $c3 >= "\x80" && $c3 <= "\xbf" && $c4 >= "\x80" && $c4 <= "\xbf") { //yeah, almost sure it's UTF8 already
+                        $buf .= $c1 . $c2 . $c3 . $c4;
+                        $i = $i + 3;
+                    } else { //not valid UTF8.  Convert it.
+                        $cc1 = (chr(intdiv(ord($c1), 64)) | "\xc0");
+                        $cc2 = ($c1 & "\x3f") | "\x80";
+                        $buf .= $cc1 . $cc2;
+                    }
+                } else { //doesn't look like UTF8, but should be converted
                     $cc1 = (chr(intdiv(ord($c1), 64)) | "\xc0");
                     $cc2 = (($c1 & "\x3f") | "\x80");
                     $buf .= $cc1 . $cc2;
+                }
+            } elseif (($c1 & "\xc0") === "\x80") { // needs conversion
+                if (isset(self::WIN1252_TO_UTF8[ord($c1)])) { //found in Windows-1252 special cases
+                    $buf .= self::WIN1252_TO_UTF8[ord($c1)];
+                } else {
+                    $cc1 = (chr(intdiv(ord($c1), 64)) | "\xc0");
+                    $cc2 = (($c1 & "\x3f") | "\x80");
+                    $buf .= $cc1 . $cc2;
+                }
+            } else { // it doesn't need conversion
+                $buf .= $c1;
             }
-        } elseif(($c1 & "\xc0") === "\x80"){ // needs conversion
-              if(isset(self::$win1252ToUtf8[ord($c1)])) { //found in Windows-1252 special cases
-                  $buf .= self::$win1252ToUtf8[ord($c1)];
-              } else {
-                $cc1 = (chr(intdiv(ord($c1), 64)) | "\xc0");
-                $cc2 = (($c1 & "\x3f") | "\x80");
-                $buf .= $cc1 . $cc2;
-              }
-        } else { // it doesn't need conversion
-            $buf .= $c1;
         }
-    }
-    return $buf;
-  }
-
-  public static function toWin1252($text, $option = self::WITHOUT_ICONV) {
-    if(is_array($text)) {
-      foreach($text as $k => $v) {
-        $text[$k] = self::toWin1252($v, $option);
-      }
-      return $text;
-    } elseif(is_string($text)) {
-      return static::utf8_decode($text, $option);
-    } else {
-      return $text;
-    }
-  }
-
-  public static function toISO8859($text, $option = self::WITHOUT_ICONV) {
-    return self::toWin1252($text, $option);
-  }
-
-  public static function toLatin1($text, $option = self::WITHOUT_ICONV) {
-    return self::toWin1252($text, $option);
-  }
-
-  public static function fixUTF8($text, $option = self::WITHOUT_ICONV){
-    if(is_array($text)) {
-      foreach($text as $k => $v) {
-        $text[$k] = self::fixUTF8($v, $option);
-      }
-      return $text;
+        return $buf;
     }
 
-    if(!is_string($text)) {
-      return $text;
+    /**
+     * @param string|string[] $text
+     * @param IconvOptions|string $option
+     * @return string|string[]|false
+     */
+    public static function toWin1252($text, IconvOptions|string $option = IconvOptions::WITHOUT_ICONV)
+    {
+        if (is_string($option)) {
+            trigger_error('Deprecated: use IconvOptions enum for $option', E_USER_DEPRECATED);
+            $option = IconvOptions::fromString($option);
+        }
+
+        if (is_array($text)) {
+            foreach ($text as $k => $v) {
+                $text[$k] = self::toWin1252($v, $option);
+            }
+            return $text;
+        }
+
+        if (is_string($text)) {
+            return static::utf8_decode($text, $option);
+        }
+
+        trigger_error('Deprecated: $text must be a string or an array of string', E_USER_DEPRECATED);
+        return $text;
     }
 
-    $last = "";
-    while($last <> $text){
-      $last = $text;
-      $text = self::toUTF8(static::utf8_decode($text, $option));
-    }
-    return self::toUTF8(static::utf8_decode($text, $option));
-  }
-
-  public static function UTF8FixWin1252Chars($text){
-    // If you received an UTF-8 string that was converted from Windows-1252 as it was ISO8859-1
-    // (ignoring Windows-1252 chars from 80 to 9F) use this function to fix it.
-    // See: http://en.wikipedia.org/wiki/Windows-1252
-
-    return str_replace(array_keys(self::$brokenUtf8ToUtf8), array_values(self::$brokenUtf8ToUtf8), $text);
-  }
-
-  public static function removeBOM($str=""){
-    if(substr($str, 0,3) === pack("CCC",0xef,0xbb,0xbf)) {
-      $str=substr($str, 3);
-    }
-    return $str;
-  }
-
-  protected static function strlen($text){
-    return (function_exists('mb_strlen') && ((int) ini_get('mbstring.func_overload')) & 2) ?
-           mb_strlen($text,'8bit') : strlen($text);
-  }
-
-  public static function normalizeEncoding($encodingLabel): string
-  {
-    $encoding = strtoupper($encodingLabel);
-    $encoding = preg_replace('/[^a-zA-Z0-9\s]/', '', $encoding);
-    $equivalences = array(
-        'ISO88591' => 'ISO-8859-1',
-        'ISO8859'  => 'ISO-8859-1',
-        'ISO'      => 'ISO-8859-1',
-        'LATIN1'   => 'ISO-8859-1',
-        'LATIN'    => 'ISO-8859-1',
-        'UTF8'     => 'UTF-8',
-        'UTF'      => 'UTF-8',
-        'WIN1252'  => 'ISO-8859-1',
-        'WINDOWS1252' => 'ISO-8859-1'
-    );
-
-    if(empty($equivalences[$encoding])){
-      return 'UTF-8';
+    /**
+     * @param string|string[] $text
+     * @param IconvOptions|string $option
+     * @return string|string[]|false
+     */
+    public static function toISO8859($text, IconvOptions|string $option = IconvOptions::WITHOUT_ICONV)
+    {
+        if (is_string($option)) {
+            trigger_error('Deprecated: use IconvOptions enum for $option', E_USER_DEPRECATED);
+            $option = IconvOptions::fromString($option);
+        }
+        return self::toWin1252($text, $option);
     }
 
-    return $equivalences[$encoding];
-  }
-
-  public static function encode($encodingLabel, $text)
-  {
-    $encodingLabel = self::normalizeEncoding($encodingLabel);
-    if($encodingLabel === 'ISO-8859-1') return self::toLatin1($text);
-    return self::toUTF8($text);
-  }
-
-  protected static function utf8_decode($text, $option = self::WITHOUT_ICONV)
-  {
-    if ($option !== self::WITHOUT_ICONV && function_exists('iconv')) {
-      return iconv("UTF-8", "Windows-1252" . ($option === self::ICONV_TRANSLIT ? '//TRANSLIT' : ($option === self::ICONV_IGNORE ? '//IGNORE' : '')), $text);
+    /**
+     * @param string|string[] $text
+     * @param IconvOptions|string $option
+     * @return string|string[]|false
+     */
+    public static function toLatin1($text, IconvOptions|string $option = IconvOptions::WITHOUT_ICONV)
+    {
+        if (is_string($option)) {
+            trigger_error('Deprecated: use IconvOptions enum for $option', E_USER_DEPRECATED);
+            $option = IconvOptions::fromString($option);
+        }
+        return self::toWin1252($text, $option);
     }
 
-    $text = str_replace(array_keys(self::$utf8ToWin1252), array_values(self::$utf8ToWin1252), self::toUTF8($text));
-    if (function_exists('mb_convert_encoding')) {
-      return mb_convert_encoding($text, 'ISO-8859-1', 'UTF-8');
+    /**
+     * @param string|string[] $text
+     * @param IconvOptions|string $option
+     * @return string|string[]
+     */
+    public static function fixUTF8($text, IconvOptions|string $option = IconvOptions::WITHOUT_ICONV)
+    {
+        if (is_string($option)) {
+            trigger_error('Deprecated: use IconvOptions enum for $option', E_USER_DEPRECATED);
+            $option = IconvOptions::fromString($option);
+        }
+        if (is_array($text)) {
+            foreach ($text as $k => $v) {
+                $text[$k] = self::fixUTF8($v, $option);
+            }
+            return $text;
+        }
+
+        if (!is_string($text)) {
+            trigger_error('Deprecated: $text must be a string or an array of string', E_USER_DEPRECATED);
+            return $text;
+        }
+
+        $last = "";
+        while ($last <> $text) {
+            $last = $text;
+            $text = self::toUTF8(static::utf8_decode($text, $option));
+        }
+        return self::toUTF8(static::utf8_decode($text, $option));
     }
 
-    if (extension_loaded('intl')) {
-      return \UConverter::transcode($text, 'ISO-8859-1', 'UTF-8');
+    /**
+     * @param string|string[] $text
+     * @return string|string[]
+     */
+    public static function UTF8FixWin1252Chars(array|string $text): array|string
+    {
+        // If you received an UTF-8 string that was converted from Windows-1252 as it was ISO8859-1
+        // (ignoring Windows-1252 chars from 80 to 9F) use this function to fix it.
+        // See: http://en.wikipedia.org/wiki/Windows-1252
+        return str_replace(
+            array_keys(self::BROKEN_UTF8_TO_UTF8),
+            array_values(self::BROKEN_UTF8_TO_UTF8),
+            $text
+        );
     }
 
-    return utf8_decode($text);
-  }
+    public static function removeBOM(string $str = ""): string
+    {
+        if (substr($str, 0, 3) === pack("CCC", 0xef, 0xbb, 0xbf)) {
+            $str = substr($str, 3);
+        }
+        return $str;
+    }
+
+    protected static function strlen(string $text): int
+    {
+        return (function_exists('mb_strlen') && ((int)ini_get('mbstring.func_overload')) & 2) ?
+            \mb_strlen($text, '8bit') : strlen($text);
+    }
+
+    public static function normalizeEncoding(string $encodingLabel): string
+    {
+        $encoding = strtoupper($encodingLabel);
+        $encoding = preg_replace('/[^a-zA-Z0-9\s]/', '', $encoding);
+        $equivalences = [
+            'ISO88591' => 'ISO-8859-1',
+            'ISO8859' => 'ISO-8859-1',
+            'ISO' => 'ISO-8859-1',
+            'LATIN1' => 'ISO-8859-1',
+            'LATIN' => 'ISO-8859-1',
+            'UTF8' => 'UTF-8',
+            'UTF' => 'UTF-8',
+            'WIN1252' => 'ISO-8859-1',
+            'WINDOWS1252' => 'ISO-8859-1'
+        ];
+
+        if (empty($equivalences[$encoding])) {
+            return 'UTF-8';
+        }
+
+        return $equivalences[$encoding];
+    }
+
+    public static function encode(string $encodingLabel, $text)
+    {
+        if (!is_array($text) && !is_string($text)) {
+            trigger_error('Deprecated: $text must be a string or an array of string', E_USER_DEPRECATED);
+            return $text;
+        }
+
+        $encodingLabel = self::normalizeEncoding($encodingLabel);
+        if ($encodingLabel === 'ISO-8859-1') {
+            return self::toLatin1($text);
+        }
+        return self::toUTF8($text);
+    }
+
+    /**
+     * @param string $text
+     * @param IconvOptions $option
+     * @return string|false
+     */
+    protected static function utf8_decode(string $text, IconvOptions $option = IconvOptions::WITHOUT_ICONV): string|false
+    {
+        if ($option !== IconvOptions::WITHOUT_ICONV && function_exists('iconv')) {
+            $iconvOption = match ($option) {
+                IconvOptions::ICONV_TRANSLIT => '//TRANSLIT',
+                IconvOptions::ICONV_IGNORE => '//IGNORE',
+            };
+            return \iconv(
+                from_encoding: "UTF-8",
+                to_encoding: "Windows-1252{$iconvOption}",
+                string: $text
+            );
+        }
+
+        $text = str_replace(
+            array_keys(self::UTF8_TO_WIN1252),
+            array_values(self::UTF8_TO_WIN1252),
+            self::toUTF8($text)
+        );
+        if (function_exists('mb_convert_encoding')) {
+            return \mb_convert_encoding($text, 'ISO-8859-1', 'UTF-8');
+        }
+
+        if (extension_loaded('intl')) {
+            return \UConverter::transcode($text, 'ISO-8859-1', 'UTF-8');
+        }
+
+        return utf8_decode($text);
+    }
 }

--- a/ForceUTF8/IconvOptions.php
+++ b/ForceUTF8/IconvOptions.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ForceUTF8;
+
+enum IconvOptions
+{
+    case ICONV_TRANSLIT;
+    case ICONV_IGNORE;
+    case WITHOUT_ICONV;
+
+    /**
+     * @deprecated Allow transition from
+     */
+    public static function fromString(string $value): IconvOptions
+    {
+        if ($value === 'TRANSLIT') {
+            return self::ICONV_TRANSLIT;
+        }
+        if ($value === 'IGNORE') {
+            return self::ICONV_IGNORE;
+        }
+        if ($value === '') {
+            return self::WITHOUT_ICONV;
+        }
+        throw new \InvalidArgumentException('Invalid option');
+    }
+}

--- a/README.md
+++ b/README.md
@@ -54,18 +54,18 @@ will output:
     
 ## Options
 
-By default, `Encoding::fixUTF8` will use the `Encoding::WITHOUT_ICONV` flag, signalling that iconv should not be used to fix garbled UTF8 strings.
+By default, `Encoding::fixUTF8` will use the `IconvOptions::WITHOUT_ICONV` flag, signalling that iconv should not be used to fix garbled UTF8 strings.
 
-This class also provides options for iconv processing, such as `Encoding::ICONV_TRANSLIT` and `Encoding::ICONV_IGNORE` to enable these flags when the iconv class is utilized. The functionality of such flags are documented in the [PHP iconv documentation](http://php.net/manual/en/function.iconv.php).
+This class also provides options for iconv processing, such as `IconvOptions::ICONV_TRANSLIT` and `IconvOptions::ICONV_IGNORE` to enable these flags when the iconv class is utilized. The functionality of such flags are documented in the [PHP iconv documentation](http://php.net/manual/en/function.iconv.php).
 
 Examples:
 
     use \ForceUTF8\Encoding;
     
     $str = "FÃÂ©dération Camerounaise—de—Football\n"; // Uses U+2014 which is invalid ISO8859-1 but exists in Win1252
-    echo Encoding::fixUTF8($str); // Will break U+2014
-    echo Encoding::fixUTF8($str, Encoding::ICONV_IGNORE); // Will preserve U+2014
-    echo Encoding::fixUTF8($str, Encoding::ICONV_TRANSLIT); // Will preserve U+2014
+    echo IconvOptions::fixUTF8($str); // Will break U+2014
+    echo IconvOptions::fixUTF8($str, Encoding::ICONV_IGNORE); // Will preserve U+2014
+    echo IconvOptions::fixUTF8($str, Encoding::ICONV_TRANSLIT); // Will preserve U+2014
 
 will output:
 
@@ -79,8 +79,8 @@ while:
 
     $str = "čęėįšųūž"; // Uses several characters not present in ISO8859-1 / Win1252
     echo Encoding::fixUTF8($str); // Will break invalid characters
-    echo Encoding::fixUTF8($str, Encoding::ICONV_IGNORE); // Will remove invalid characters, keep those present in Win1252
-    echo Encoding::fixUTF8($str, Encoding::ICONV_TRANSLIT); // Will trasliterate invalid characters, keep those present in Win1252
+    echo Encoding::fixUTF8($str, IconvOptions::ICONV_IGNORE); // Will remove invalid characters, keep those present in Win1252
+    echo Encoding::fixUTF8($str, IconvOptions::ICONV_TRANSLIT); // Will trasliterate invalid characters, keep those present in Win1252
 
 will output:
 

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,12 @@
     "description": "PHP Class Encoding featuring popular Encoding::toUTF8() function --formerly known as forceUTF8()-- that fixes mixed encoded strings.",
     "readme": "README.md",
     "require": {
-        "php": "^7.0 || ^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6"
+        "ext-dom": "*",
+        "phpunit/phpunit": "^10.0",
+        "phpstan/phpstan": "^1.12"
     },
     "suggest": {
         "ext-iconv": "To convert non-UTF-8 strings to UTF-8",
@@ -30,7 +32,8 @@
     },
     "archive": {
         "exclude": [
-            "tests"
+            "tests",
+            "phpstan.neon"
         ]
     },
     "extra": {
@@ -40,6 +43,7 @@
         }
     },
     "scripts": {
-        "tests": " ./vendor/bin/phpunit tests"
+        "tests": " ./vendor/bin/phpunit tests",
+        "phpstan": "./vendor/phpstan/phpstan/phpstan analyse -c phpstan.neon --memory-limit=4096M --error-format=table --no-progress -vvv"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+parameters:
+  excludePaths:
+    - tests/*
+  inferPrivatePropertyTypeFromConstructor: true
+  level: 5
+  paths:
+    - ForceUTF8
+  ignoreErrors:


### PR DESCRIPTION
- Updated required PHP version to 8.1 (latest supported to date).
- Changed parameter & return types where possible
- Raised deprecation error when library is used in unintended way (i.e., not working on string)